### PR TITLE
Enable useless linting supression detection

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
+[MESSAGE CONTROL]
+enable=useless-suppression
+
 [SIMILARITIES]
 ignore-imports=yes

--- a/illud/main.py
+++ b/illud/main.py
@@ -21,9 +21,9 @@ def _run_illud(parsed_arguments: argparse.Namespace) -> None:  # pylint: disable
     """Run Illud."""
 
 
-def main(arguments: List[str]) -> int:  # pylint: disable=unused-argument
+def main(arguments: List[str]) -> int:
     """Main entry point."""
     argument_parser: argparse.ArgumentParser = _set_up_argument_parser()
-    parsed_arguments: argparse.Namespace = _parse_arguments(argument_parser, arguments)  # pylint: disable=unused-variable
+    parsed_arguments: argparse.Namespace = _parse_arguments(argument_parser, arguments)
     _run_illud(parsed_arguments)
     return 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,21 +56,21 @@ def test_parse_arguments(argument_parser: argparse.ArgumentParser, arguments: Li
     assert parsed_arguments == expected_parsed_arguments
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('parsed_arguments', [
     (argparse.Namespace()),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_run_illud(parsed_arguments: argparse.Namespace) -> None:
     """Test illud.main._run_illud."""
     _run_illud(parsed_arguments)
 
 
-# yapf: disable # pylint: disable=line-too-long
+# yapf: disable
 @pytest.mark.parametrize('arguments, expected_return_value', [
     ([], 0),
 ])
-# yapf: enable # pylint: enable=line-too-long
+# yapf: enable
 def test_main(arguments: List[str], expected_return_value: int) -> None:
     """Test illud.main.main."""
     with patch('illud.main._set_up_argument_parser') as set_up_argument_parser_mock, \


### PR DESCRIPTION
Enable pylint to warn about useless supression of warnings and errors.