### PR TITLE
Fix terminal clear screen

### DIFF
--- a/illud/terminal.py
+++ b/illud/terminal.py
@@ -19,3 +19,4 @@ class Terminal():
     def clear_screen(self) -> None:
         """Clear the terminal of all characters."""
         self._standard_output.write(CLEAR_SCREEN)
+        self._standard_output.flush()

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -53,3 +53,4 @@ def test_clear_screen() -> None:
     terminal.clear_screen()
 
     standard_output_mock.write.assert_called_once_with(CLEAR_SCREEN)
+    standard_output_mock.flush.assert_called_once()


### PR DESCRIPTION
Fix the ability of the terminal to clear the screen by flushing the ANSI
escape code after it has been written.