### PR TITLE
Ascola/add standard input expect

### DIFF
--- a/illud/exceptions/unexpected_input_exception.py
+++ b/illud/exceptions/unexpected_input_exception.py
@@ -1,0 +1,6 @@
+"""Raised when there is an unexpected input."""
+from illud.exception import IlludException
+
+
+class UnexpectedInputException(IlludException):
+    """Raised when there is an unexpected input."""

--- a/illud/inputs/standard_input.py
+++ b/illud/inputs/standard_input.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, TextIO
 
 from illud.character import Character, CharacterIterator
 from illud.exceptions.invalid_number_exception import InvalidNumberException
+from illud.exceptions.unexpected_input_exception import UnexpectedInputException
 from illud.input import Input
 
 TeletypeAttributes = List[Any]
@@ -83,6 +84,13 @@ class StandardInput(Input):
         else:
             self._buffer = ''
             self._stdin.read(length - buffer_length)
+
+    def expect(self, string: str) -> None:
+        """Asserts that the input matches the expected string."""
+        for expected_character in string:
+            character: str = self.read(1)
+            if character != expected_character:
+                raise UnexpectedInputException
 
     def read_integer(self) -> int:
         """Return an integer."""

--- a/tests/exceptions/test_unexpected_input_exception.py
+++ b/tests/exceptions/test_unexpected_input_exception.py
@@ -1,0 +1,8 @@
+"""Test illud.exceptions.unexpected_input_exception."""
+from illud.exception import IlludException
+from illud.exceptions.unexpected_input_exception import UnexpectedInputException
+
+
+def test_inheritance() -> None:
+    """Test illud.exceptions.unexpected_input_exception.UnexpectedInputException inheritance."""
+    assert issubclass(UnexpectedInputException, IlludException)


### PR DESCRIPTION
Add the ability to expect an input string from the standard input.