### PR TITLE
Ascola/add terminal cursor

### DIFF
--- a/illud/ansi/escape_codes/cursor.py
+++ b/illud/ansi/escape_codes/cursor.py
@@ -1,0 +1,4 @@
+"""ANSI escape codes for the cursor position."""
+from illud.ansi.escape_codes.control import CONTROL_SEQUENCE_INTRODUCER
+
+DEVICE_STATUS_REPORT = CONTROL_SEQUENCE_INTRODUCER + '6n'

--- a/illud/terminal_cursor.py
+++ b/illud/terminal_cursor.py
@@ -1,0 +1,25 @@
+"""The cursor of a terminal."""
+from illud.ansi.escape_codes.cursor import DEVICE_STATUS_REPORT
+from illud.inputs.standard_input import StandardInput
+from illud.integer_position_2d import IntegerPosition2D
+from illud.outputs.standard_output import StandardOutput
+
+
+class TerminalCursor():  # pylint: disable=too-few-public-methods
+    """The cursor of a terminal."""
+    def __init__(self, standard_input: StandardInput, standard_output: StandardOutput):
+        self._standard_input: StandardInput = standard_input
+        self._standard_output: StandardOutput = standard_output
+
+        self._position: IntegerPosition2D = self._get_position_from_terminal()
+
+    def _get_position_from_terminal(self) -> IntegerPosition2D:
+        """Return the position of the cursor as reported by the terminal."""
+        self._standard_output.write(DEVICE_STATUS_REPORT)
+
+        y: int = self._standard_input.maybe_read_integer(default=0)  # pylint: disable=invalid-name
+        self._standard_input.expect(';')
+        x: int = self._standard_input.maybe_read_integer(default=0)  # pylint: disable=invalid-name
+        self._standard_input.expect('R')
+
+        return IntegerPosition2D(x, y)

--- a/tests/ansi/escape_codes/test_cursor.py
+++ b/tests/ansi/escape_codes/test_cursor.py
@@ -1,0 +1,7 @@
+"""Test illud.ansi.escape_codes.cursor."""
+from illud.ansi.escape_codes.cursor import DEVICE_STATUS_REPORT
+
+
+def test_clear_screen() -> None:
+    """Test illud.ansi.escape_codes.cursor.DEVICE_STATUS_REPORT."""
+    assert DEVICE_STATUS_REPORT == '\x1b[6n'

--- a/tests/test_terminal_cursor.py
+++ b/tests/test_terminal_cursor.py
@@ -1,0 +1,58 @@
+"""Test illud.terminal_cursor."""
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from illud.ansi.escape_codes.cursor import DEVICE_STATUS_REPORT
+from illud.inputs.standard_input import StandardInput
+from illud.integer_position_2d import IntegerPosition2D
+from illud.outputs.standard_output import StandardOutput
+from illud.terminal_cursor import TerminalCursor
+
+
+# yapf: disable
+@pytest.mark.parametrize('position, expected_position', [
+    (IntegerPosition2D(0, 0), IntegerPosition2D(0, 0)),
+])
+# yapf: enable
+def test_init(position: IntegerPosition2D, expected_position: IntegerPosition2D) -> None:
+    """Test illud.terminal_cursor.TerminalCursor.__init__."""
+    standard_input_mock = MagicMock(StandardInput)
+    standard_output_mock = MagicMock(StandardOutput)
+    with patch('illud.terminal_cursor.TerminalCursor._get_position_from_terminal',
+               return_value=position):
+        terminal_cursor: TerminalCursor = TerminalCursor(standard_input_mock, standard_output_mock)
+
+    assert terminal_cursor._position == expected_position  # pylint: disable=protected-access
+    assert terminal_cursor._standard_input == standard_input_mock  # pylint: disable=protected-access
+    assert terminal_cursor._standard_output == standard_output_mock  # pylint: disable=protected-access
+
+
+# yapf: disable
+@pytest.mark.parametrize('cursor_position_report, expected_position', [
+    (';R', IntegerPosition2D(0, 0)),
+    ('1;R', IntegerPosition2D(0, 1)),
+    (';1R', IntegerPosition2D(1, 0)),
+    ('1;1R', IntegerPosition2D(1, 1)),
+])
+# yapf: enable
+def test_get_position_from_terminal(cursor_position_report: str,
+                                    expected_position: IntegerPosition2D) -> None:
+    """Test illud.terminal_cursor.TerminalCursor._get_position_from_terminal."""
+    with patch('sys.stdin', StringIO(cursor_position_report)), \
+        patch.object(StandardInput, '_get_attributes'), \
+        patch.object(StandardInput, '_use_raw_mode'):
+
+        standard_input: StandardInput = StandardInput()
+
+    with patch('illud.outputs.standard_output.StandardOutput.write') as standard_output_write_mock:
+        standard_output: StandardOutput = StandardOutput()
+
+        with patch('illud.terminal_cursor.TerminalCursor._get_position_from_terminal'):
+            terminal_cursor: TerminalCursor = TerminalCursor(standard_input, standard_output)
+
+        position: IntegerPosition2D = terminal_cursor._get_position_from_terminal()  # pylint: disable=protected-access
+
+        assert position == expected_position
+        standard_output_write_mock.assert_called_once_with(DEVICE_STATUS_REPORT)


### PR DESCRIPTION
Add a representation of the cursor of the terminal. Get the initial
cursor position on initialization.