### PR TITLE
Ascola/fix terminal cursor get position

### DIFF
--- a/illud/terminal_cursor.py
+++ b/illud/terminal_cursor.py
@@ -1,6 +1,7 @@
 """The cursor of a terminal."""
 from typing import Any
 
+from illud.ansi.escape_codes.control import CONTROL_SEQUENCE_INTRODUCER
 from illud.ansi.escape_codes.cursor import DEVICE_STATUS_REPORT, get_move_cursor
 from illud.inputs.standard_input import StandardInput
 from illud.integer_position_2d import IntegerPosition2D
@@ -20,6 +21,7 @@ class TerminalCursor():
         self._standard_output.write(DEVICE_STATUS_REPORT)
         self._standard_output.flush()
 
+        self._standard_input.expect(CONTROL_SEQUENCE_INTRODUCER)
         y: int = self._standard_input.maybe_read_integer(default=0)  # pylint: disable=invalid-name
         self._standard_input.expect(';')
         x: int = self._standard_input.maybe_read_integer(default=0)  # pylint: disable=invalid-name

--- a/illud/terminal_cursor.py
+++ b/illud/terminal_cursor.py
@@ -18,6 +18,7 @@ class TerminalCursor():
     def _get_position_from_terminal(self) -> IntegerPosition2D:
         """Return the position of the cursor as reported by the terminal."""
         self._standard_output.write(DEVICE_STATUS_REPORT)
+        self._standard_output.flush()
 
         y: int = self._standard_input.maybe_read_integer(default=0)  # pylint: disable=invalid-name
         self._standard_input.expect(';')

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -67,7 +67,7 @@ def test_clear_screen() -> None:
     terminal.clear_screen()
 
     standard_output_mock.write.assert_has_calls([call(DEVICE_STATUS_REPORT), call(CLEAR_SCREEN)])
-    standard_output_mock.flush.assert_called_once()
+    assert len(standard_output_mock.flush.mock_calls) == 2
 
 
 # yapf: disable # pylint: disable=line-too-long

--- a/tests/test_terminal_cursor.py
+++ b/tests/test_terminal_cursor.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from pytest import CaptureFixture
 
 from illud.ansi.escape_codes.cursor import DEVICE_STATUS_REPORT
 from illud.inputs.standard_input import StandardInput
@@ -39,7 +40,7 @@ def test_init(position: IntegerPosition2D, expected_position: IntegerPosition2D)
     ('1;1R', IntegerPosition2D(1, 1)),
 ])
 # yapf: enable
-def test_get_position_from_terminal(cursor_position_report: str,
+def test_get_position_from_terminal(capsys: CaptureFixture, cursor_position_report: str,
                                     expected_position: IntegerPosition2D) -> None:
     """Test illud.terminal_cursor.TerminalCursor._get_position_from_terminal."""
     with patch('sys.stdin', StringIO(cursor_position_report)), \
@@ -48,16 +49,17 @@ def test_get_position_from_terminal(cursor_position_report: str,
 
         standard_input: StandardInput = StandardInput()
 
-    with patch('illud.outputs.standard_output.StandardOutput.write') as standard_output_write_mock:
-        standard_output: StandardOutput = StandardOutput()
+    standard_output: StandardOutput = StandardOutput()
 
-        with patch('illud.terminal_cursor.TerminalCursor._get_position_from_terminal'):
-            terminal_cursor: TerminalCursor = TerminalCursor(standard_input, standard_output)
+    with patch('illud.terminal_cursor.TerminalCursor._get_position_from_terminal'):
+        terminal_cursor: TerminalCursor = TerminalCursor(standard_input, standard_output)
 
-        position: IntegerPosition2D = terminal_cursor._get_position_from_terminal()  # pylint: disable=protected-access
+    position: IntegerPosition2D = terminal_cursor._get_position_from_terminal()  # pylint: disable=protected-access
 
-        assert position == expected_position
-        standard_output_write_mock.assert_called_once_with(DEVICE_STATUS_REPORT)
+    assert position == expected_position
+
+    captured_output: str = capsys.readouterr().out
+    assert captured_output == DEVICE_STATUS_REPORT
 
 
 # yapf: disable # pylint: disable=line-too-long

--- a/tests/test_terminal_cursor.py
+++ b/tests/test_terminal_cursor.py
@@ -34,10 +34,10 @@ def test_init(position: IntegerPosition2D, expected_position: IntegerPosition2D)
 
 # yapf: disable
 @pytest.mark.parametrize('cursor_position_report, expected_position', [
-    (';R', IntegerPosition2D(0, 0)),
-    ('1;R', IntegerPosition2D(0, 1)),
-    (';1R', IntegerPosition2D(1, 0)),
-    ('1;1R', IntegerPosition2D(1, 1)),
+    ('\x1b[;R', IntegerPosition2D(0, 0)),
+    ('\x1b[1;R', IntegerPosition2D(0, 1)),
+    ('\x1b[;1R', IntegerPosition2D(1, 0)),
+    ('\x1b[1;1R', IntegerPosition2D(1, 1)),
 ])
 # yapf: enable
 def test_get_position_from_terminal(capsys: CaptureFixture, cursor_position_report: str,


### PR DESCRIPTION
Fix getting the terminal cursor position. There were really two problems here:
- The device status report was not being flushed.
- The response included a control sequence introducer which was not expected.