### PR TITLE
Add character printable

### DIFF
--- a/illud/character.py
+++ b/illud/character.py
@@ -1,8 +1,9 @@
 """A single string character."""
+import string
 from typing import Any, Iterator
 
 
-class Character():  # pylint: disable=too-few-public-methods
+class Character():
     """A single string character."""
     def __init__(self, value: str):
         self.value: str = value
@@ -11,6 +12,11 @@ class Character():  # pylint: disable=too-few-public-methods
         if not isinstance(other, Character):
             return False
         return self.value == other.value
+
+    @property
+    def printable(self) -> bool:
+        """Return if the character is a printable character or not."""
+        return self.value in string.printable
 
 
 CharacterIterator = Iterator[Character]

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -29,3 +29,16 @@ def test_eq(character: Character, other: Any, expected_equality: bool) -> None:
     """Test illud.character.Character.__eq__."""
     equality: bool = character == other
     assert equality == expected_equality
+
+
+# yapf: disable
+@pytest.mark.parametrize('character, expected_printable', [
+    (Character('a'), True),
+    (Character('\x07'), False),
+])
+# yapf: enable
+def test_printable(character: Character, expected_printable: bool) -> None:
+    """Test illud.character.Character.printable."""
+    printable: bool = character.printable
+
+    assert printable == expected_printable


### PR DESCRIPTION
Add a property to characters to return where the character is a
printable character or not.

Note that `string.printable` is a list. Testing for membership in a dict
might be faster?