### PR TITLE
Add buffer insert string

### DIFF
--- a/illud/buffer.py
+++ b/illud/buffer.py
@@ -40,3 +40,7 @@ class Buffer():
            if the substring is not found."""
         index: int = self.string.index(substring, start, end)
         return index
+
+    def insert(self, string: str, position: int) -> None:
+        """Insert a string at the given position in the buffer."""
+        self.string = self.string[:position] + string + self.string[position:]

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -123,3 +123,21 @@ def test_index(buffer_: Buffer, substring: str, start: Optional[int], pass_start
 
 
 # pylint: enable=too-many-arguments
+
+
+# yapf: disable
+@pytest.mark.parametrize('buffer_, string, position, expected_buffer_after', [
+    (Buffer(), '', 0, Buffer()),
+    (Buffer(), 'f', 0, Buffer('f')),
+    (Buffer(), 'foo', 0, Buffer('foo')),
+    (Buffer('bar'), 'foo', 0, Buffer('foobar')),
+    (Buffer('foo'), '', 1, Buffer('foo')),
+    (Buffer('fo'), 'o', 1, Buffer('foo')),
+    (Buffer('foo'), 'bar', 3, Buffer('foobar')),
+])
+# yapf: enable
+def test_insert(buffer_: Buffer, string: str, position: int, expected_buffer_after: str) -> None:
+    """Test illud.buffer.Buffer.insert."""
+    buffer_.insert(string, position)
+
+    assert buffer_ == expected_buffer_after


### PR DESCRIPTION
Add the ability to insert a string at a given position in a buffer.

Since strings are immutable, this might be costly. It might be more
efficent to store the buffer string differently internally.