### PR TITLE
Add insert mode evaluation

### DIFF
--- a/illud/modes/insert.py
+++ b/illud/modes/insert.py
@@ -1,6 +1,20 @@
 """Mode for inserting text."""
+from typing import TYPE_CHECKING
+
+from illud.character import Character
+from illud.command import Command
 from illud.mode import Mode
+
+if TYPE_CHECKING:
+    from illud.illud_state import IlludState  # pylint: disable=cyclic-import
 
 
 class Insert(Mode):  # pylint: disable=too-few-public-methods
     """Mode for inserting text."""
+    @staticmethod
+    def evaluate(state: 'IlludState', command: Command) -> None:
+        """Evaluate the command for the given state."""
+        character: Character = command.character
+        if character.printable:
+            string: str = character.value
+            state.cursor.insert(string)

--- a/tests/modes/test_insert.py
+++ b/tests/modes/test_insert.py
@@ -1,4 +1,10 @@
 """Test illud.modes.insert."""
+import pytest
+
+from illud.buffer import Buffer
+from illud.character import Character
+from illud.command import Command
+from illud.illud_state import IlludState
 from illud.mode import Mode
 from illud.modes.insert import Insert
 
@@ -6,3 +12,15 @@ from illud.modes.insert import Insert
 def test_inheritance() -> None:
     """Test illud.modes.insert.Insert inheritance."""
     assert issubclass(Insert, Mode)
+
+
+# yapf: disable # pylint: disable=line-too-long
+@pytest.mark.parametrize('state, command, expected_state_after', [
+    (IlludState(mode=Insert()), Command(Character('a')), IlludState(buffer_=Buffer('a'), mode=Insert())),
+])
+# yapf: enable # pylint: enable=line-too-long
+def test_evaluate(state: IlludState, command: Command, expected_state_after: IlludState) -> None:
+    """Test illud.modes.insert.Insert.evaluate."""
+    Insert.evaluate(state, command)
+
+    assert state == expected_state_after


### PR DESCRIPTION
Add evaluation in the insert mode. For now, just insert printable
characters. Exiting insert mode, and handling other inputs like arrow
keys or backspaces also needs to be supported.