### PR TITLE
Remove dependency installation from action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,11 +15,6 @@ jobs:
       with:
         python-version: 3.6
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip setuptools wheel
-        python3 -m pip install -r requirements/test_requirements.txt
-
     - name: Test with pytest
       run: |
         ./scripts/coverage.sh


### PR DESCRIPTION
Remove the installation of dependencies from the GitHub Action because
the scripts handle their own venvs now.