### PR TITLE
Change buffer default value

### DIFF
--- a/illud/buffer.py
+++ b/illud/buffer.py
@@ -9,12 +9,8 @@ from seligimus.python.decorators.standard_representation import standard_represe
 
 class Buffer():
     """A string buffer."""
-    def __init__(self, string: Optional[str] = None):
-        self.string: str
-        if string is None:
-            self.string = ''
-        else:
-            self.string = string
+    def __init__(self, string: str = ''):
+        self.string: str = string
 
     @equal_type
     @equal_instance_attributes

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -7,16 +7,16 @@ from illud.buffer import Buffer
 
 
 # yapf: disable
-@pytest.mark.parametrize('string, expected_string', [
-    (None, ''),
-    ('', ''),
-    ('foo', 'foo'),
+@pytest.mark.parametrize('string, pass_string, expected_string', [
+    ('', False, ''),
+    ('', True, ''),
+    ('foo', True, 'foo'),
 ])
 # yapf: enable
-def test_init(string: Optional[str], expected_string: str) -> None:
+def test_init(string: str, pass_string: bool, expected_string: str) -> None:
     """Test illud.buffer.Buffer.__init__."""
     arguments: List[Any] = []
-    if string is not None:
+    if pass_string:
         arguments.append(string)
 
     buffer_: Buffer = Buffer(*arguments)
@@ -41,7 +41,7 @@ def test_eq(buffer_: Buffer, other: Any, expected_equality: bool) -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('buffer_, expected_representation', [
-    (Buffer(), 'Buffer(string=\'\')'),
+    (Buffer(), 'Buffer()'),
     (Buffer('foo'), "Buffer(string='foo')"),
     (Buffer("'"), 'Buffer(string="\'")'),
     (Buffer('"'), 'Buffer(string=\'"\')'),

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -38,7 +38,7 @@ def test_eq(cursor: Cursor, other: Any, expected_equality: bool) -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('cursor, expected_representation', [
-    (Cursor(Buffer(), 0), 'Cursor(Buffer(string=\'\'), 0)'),
+    (Cursor(Buffer(), 0), 'Cursor(Buffer(), 0)'),
     (Cursor(Buffer('foo'), 0), "Cursor(Buffer(string='foo'), 0)"),
 ])
 # yapf: enable

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -177,7 +177,7 @@ def test_eq(window: Window, other: Any, expected_equality: bool) -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('window, expected_representation', [
-    (Window(IntegerPosition2D(0, 0), IntegerSize2D(0, 0), Buffer()), 'Window(IntegerPosition2D(0, 0), IntegerSize2D(0, 0), Buffer(string=\'\'))'),
+    (Window(IntegerPosition2D(0, 0), IntegerSize2D(0, 0), Buffer()), 'Window(IntegerPosition2D(0, 0), IntegerSize2D(0, 0), Buffer())'),
     (Window(IntegerPosition2D(0, 0), IntegerSize2D(0, 0), Buffer('foo')), 'Window(IntegerPosition2D(0, 0), IntegerSize2D(0, 0), Buffer(string=\'foo\'))'),
 ])
 # yapf: enable # pylint: enable=line-too-long


### PR DESCRIPTION
Change the default value for buffers from `None` to an empty string.
Strings are immutable and so it is okay to have a string as the default
value.