### PR TITLE
Fix Illud state equality operator

### DIFF
--- a/illud/illud_state.py
+++ b/illud/illud_state.py
@@ -3,6 +3,8 @@ from typing import Any, Optional
 
 from seligimus.maths.integer_position_2d import IntegerPosition2D
 from seligimus.maths.integer_size_2d import IntegerSize2D
+from seligimus.python.decorators.operators.equality.equal_instance_attributes import \
+    equal_instance_attributes
 from seligimus.python.decorators.operators.equality.equal_type import equal_type
 
 from illud.buffer import Buffer
@@ -45,11 +47,6 @@ class IlludState(State):  # pylint: disable=too-few-public-methods
             self.window = Window(IntegerPosition2D(0, 0), IntegerSize2D(0, 0), self.buffer)
 
     @equal_type
+    @equal_instance_attributes
     def __eq__(self, other: Any) -> bool:
-        if self.buffer != other.buffer:
-            return False
-
-        if self.mode != other.mode:
-            return False
-
         return True

--- a/tests/modes/test_insert.py
+++ b/tests/modes/test_insert.py
@@ -16,7 +16,7 @@ def test_inheritance() -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('state, command, expected_state_after', [
-    (IlludState(mode=Insert()), Command(Character('a')), IlludState(buffer_=Buffer('a'), mode=Insert())),
+    (IlludState(mode=Insert()), Command(Character('a')), IlludState(buffer_=Buffer('a'), cursor_position=1, mode=Insert())),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_evaluate(state: IlludState, command: Command, expected_state_after: IlludState) -> None:

--- a/tests/test_illud_state.py
+++ b/tests/test_illud_state.py
@@ -60,19 +60,23 @@ def test_init(buffer_: Optional[Buffer], cursor_position: Optional[int], mode: O
     assert illud_state.window.buffer is illud_state.buffer
 
 
-# yapf: disable
+# yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('illud_state, other, expected_equality', [
     (IlludState(), 'foo', False),
     (IlludState(), IlludState(), True),
     (IlludState(Buffer('foo')), IlludState(), False),
     (IlludState(Buffer('foo')), IlludState(Buffer('bar')), False),
     (IlludState(Buffer('foo')), IlludState(Buffer('foo')), True),
+    (IlludState(cursor_position=1), IlludState(), False),
+    (IlludState(cursor_position=1), IlludState(cursor_position=1), True),
     (IlludState(mode=Normal()), IlludState(mode=Insert()), False),
     (IlludState(mode=Normal()), IlludState(mode=Normal()), True),
+    (IlludState(terminal_size=IntegerSize2D(3, 4)), IlludState(), False),
+    (IlludState(terminal_size=IntegerSize2D(3, 4)), IlludState(terminal_size=IntegerSize2D(3, 4)), True),
     (IlludState(Buffer('foo'), mode=Normal()), IlludState(Buffer('bar'), mode=Normal()), False),
     (IlludState(Buffer('foo'), mode=Normal()), IlludState(Buffer('foo'), mode=Normal()), True),
 ])
-# yapf: enable
+# yapf: enable # pylint: enable=line-too-long
 def test_eq(illud_state: IlludState, other: Any, expected_equality: bool) -> None:
     """Test illud.illud_state.IlludState.__eq__."""
     equality: bool = illud_state == other


### PR DESCRIPTION
Fix the Illud state equality operator to test all instance attributes
for equality using the Seligimug decorator.