### PR TITLE
Fix expected buffer after type

### DIFF
--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -152,7 +152,7 @@ def test_index(buffer_: Buffer, substring: str, start: Optional[int], pass_start
     (Buffer('foo'), 'bar', 3, Buffer('foobar')),
 ])
 # yapf: enable
-def test_insert(buffer_: Buffer, string: str, position: int, expected_buffer_after: str) -> None:
+def test_insert(buffer_: Buffer, string: str, position: int, expected_buffer_after: Buffer) -> None:
     """Test illud.buffer.Buffer.insert."""
     buffer_.insert(string, position)
 


### PR DESCRIPTION
Fix the type of the expected buffer after inserting a string into a
buffer.