### PR TITLE
Add action status badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Illud
+[![Python package](https://github.com/AustinScola/illud/actions/workflows/python-package.yml/badge.svg)](https://github.com/AustinScola/illud/actions/workflows/python-package.yml)
 
 A text buffer editor and terminal viewer.


### PR DESCRIPTION
Add a status badge for the GitHub Action to the readme.