### PR TITLE
Ascola/add repl startup

### DIFF
--- a/illud/illud.py
+++ b/illud/illud.py
@@ -17,7 +17,6 @@ class Illud(REPL):
     """A text buffer editor and terminal viewer."""
     def __init__(self, initial_state: Optional[IlludState] = None) -> None:
         self._terminal: Terminal = Terminal()
-        self._terminal.clear_screen()
 
         self._state: IlludState
         if initial_state is None:
@@ -25,6 +24,8 @@ class Illud(REPL):
         else:
             self._state = initial_state
 
+    def startup(self) -> None:
+        self._terminal.clear_screen()
         self.print(None)
 
     def read(self) -> Command:

--- a/illud/repl.py
+++ b/illud/repl.py
@@ -7,7 +7,9 @@ from illud.exceptions.break_exception import BreakException
 class REPL():
     """Read, evaluate, print, and then loop."""
     def __call__(self) -> None:
-        """Read, evaluate, print, and then loop."""
+        """Perform one-time startup, then read, evaluate, print, and loop."""
+        self.startup()
+
         while True:
             try:
                 input_: Any = self.read()
@@ -18,6 +20,9 @@ class REPL():
             except Exception as exception:  # pylint: disable=broad-except
                 self.catch(exception)
                 return
+
+    def startup(self) -> None:
+        """Perform one-time startup."""
 
     def read(self) -> Any:
         """Return the next input."""

--- a/tests/test_illud.py
+++ b/tests/test_illud.py
@@ -42,17 +42,28 @@ def test_init(illud_initial_state: Optional[IlludState], pass_illud_initial_stat
 
     terminal_get_size_mock = MagicMock(return_value=terminal_size)
     terminal_mock = MagicMock(get_size=terminal_get_size_mock)
-    with patch('illud.illud.Terminal', return_value=terminal_mock), \
-        patch('illud.illud.Illud.print') as print_mock:
+    with patch('illud.illud.Terminal', return_value=terminal_mock):
 
         illud: Illud = Illud(**keyword_arguments)
 
         assert illud._terminal == terminal_mock  # pylint: disable=protected-access
-        terminal_mock.clear_screen.assert_called_once()
 
         assert illud._state == expected_illud_state  # pylint: disable=protected-access
 
-        print_mock.assert_called_once()
+
+def test_startup() -> None:
+    """Test illud.illud.Illud.startup."""
+    clear_screen_mock = MagicMock()
+    terminal_mock = MagicMock(Terminal, autospec=True, clear_screen=clear_screen_mock)
+    with patch('illud.illud.Terminal', return_value=terminal_mock), \
+        patch('illud.illud.Illud.print') as print_mock:
+
+        illud: Illud = Illud()
+
+        illud.startup()
+
+        clear_screen_mock.assert_called_once()
+        print_mock.assert_called_once_with(None)
 
 
 # yapf: disable

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -35,12 +35,15 @@ def test_call(input_or_exception: List[Any], result_or_exception: List[Any],
     """Test illud.repl.REPL.run."""
     repl: REPL = REPL()
 
-    with patch('illud.repl.REPL.read', side_effect=input_or_exception) as read_mock, \
+    with patch('illud.repl.REPL.startup') as startup_mock, \
+        patch('illud.repl.REPL.read', side_effect=input_or_exception) as read_mock, \
         patch('illud.repl.REPL.evaluate', side_effect=result_or_exception) as evaluate_mock, \
         patch('illud.repl.REPL.print', side_effect=output_or_exception) as print_mock, \
         patch('illud.repl.REPL.catch') as catch_mock:
 
         repl()
+
+        startup_mock.assert_called_once()
 
         assert read_mock.call_count == expected_input_call_count
 
@@ -54,6 +57,13 @@ def test_call(input_or_exception: List[Any], result_or_exception: List[Any],
             catch_mock.assert_called_once()
         else:
             catch_mock.assert_not_called()
+
+
+def test_startup() -> None:
+    """Test illud.repl.REPL.startup."""
+    repl: REPL = REPL()
+
+    repl.startup()
 
 
 def test_read() -> None:


### PR DESCRIPTION
Add a way to perform one-time startup to a REPL and change Illud to use it for clearing the screen and the initial draw.