### PR TITLE
Ascola/add terminal update

### DIFF
--- a/illud/illud.py
+++ b/illud/illud.py
@@ -43,6 +43,8 @@ class Illud(REPL):
         cursor: Cursor = self._state.cursor
         self._terminal.draw_window(window, cursor)
 
+        self._terminal.update()
+
     def catch(self, exception: Exception) -> None:
         if isinstance(exception, QuitException):
             self._terminal.clear_screen()

--- a/illud/terminal.py
+++ b/illud/terminal.py
@@ -91,8 +91,6 @@ class Terminal():
                 self._cursor.move(IntegerPosition2D(window.position.x, row))
                 self._standard_output.write(' ' * window.size.width)
 
-        self._standard_output.flush()
-
     def update(self) -> None:
         """Update the terminal contents."""
         self._standard_output.flush()

--- a/illud/terminal.py
+++ b/illud/terminal.py
@@ -92,3 +92,7 @@ class Terminal():
                 self._standard_output.write(' ' * window.size.width)
 
         self._standard_output.flush()
+
+    def update(self) -> None:
+        """Update the terminal contents."""
+        self._standard_output.flush()

--- a/tests/test_illud.py
+++ b/tests/test_illud.py
@@ -125,6 +125,7 @@ def test_print(illud_state: IlludState, result: Any, expected_output: str) -> No
     output: str = ''.join(calls_args)
 
     assert output == expected_output
+    standard_output_mock.flush.assert_called_once()
 
 
 # yapf: disable

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -155,3 +155,17 @@ def test_draw_window(window: Window, cursor: Optional[Cursor], expected_output: 
 
     if expected_output:
         standard_output_mock.flush.assert_called_once()
+
+
+def test_update() -> None:
+    """Test illud.terminal.Terminal.draw_update."""
+    standard_output_mock = MagicMock(StandardOutput, autospec=True)
+    with patch('illud.terminal.StandardInput'), \
+        patch('illud.terminal.StandardOutput', return_value=standard_output_mock):
+
+        terminal: Terminal = Terminal()
+        standard_output_mock.flush.reset_mock()
+
+        terminal.update()
+
+    standard_output_mock.flush.assert_called_once()

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -153,9 +153,6 @@ def test_draw_window(window: Window, cursor: Optional[Cursor], expected_output: 
 
     assert list(output) == list(expected_output)
 
-    if expected_output:
-        standard_output_mock.flush.assert_called_once()
-
 
 def test_update() -> None:
     """Test illud.terminal.Terminal.draw_update."""


### PR DESCRIPTION
Add a terminal update method to flush stdout and update the displayed
contents of the terminal. Also move updating into print instead of draw
methods.