### PR TITLE
Ascola/refactor cursor drawing

### DIFF
--- a/illud/buffer.py
+++ b/illud/buffer.py
@@ -55,6 +55,18 @@ class Buffer():
         index: int = self.string.rindex(substring, start, end)
         return index
 
+    def get_row(self, index: int) -> int:
+        """Return the row number of an index in the buffer."""
+        if index > len(self):
+            raise BufferIndexException(index, len(self))
+
+        if not self:
+            return 0
+
+        row: int = self.string.count('\n', 0, index)
+
+        return row
+
     def get_column(self, index: int) -> int:
         """Return the column number of an index in the buffer."""
         if not 0 <= index < len(self):

--- a/illud/illud.py
+++ b/illud/illud.py
@@ -40,8 +40,10 @@ class Illud(REPL):
 
     def print(self, result: Any) -> None:
         window: Window = self._state.window
+        self._terminal.draw_window(window)
+
         cursor: Cursor = self._state.cursor
-        self._terminal.draw_window(window, cursor)
+        self._terminal.draw_cursor(cursor)
 
         self._terminal.update()
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -201,6 +201,36 @@ def test_reverse_index(buffer_: Buffer, substring: str, start: Optional[int], pa
 
 
 # yapf: disable
+@pytest.mark.parametrize('buffer_, index, expected_exception, expected_row', [
+    (Buffer(), 1, BufferIndexException(1, 0), None),
+    (Buffer(), 0, None, 0),
+    (Buffer(''), 0, None, 0),
+    (Buffer('foo'), 0, None, 0),
+    (Buffer('foo'), 1, None, 0),
+    (Buffer('foo'), 2, None, 0),
+    (Buffer('foo\nbar'), 3, None, 0),
+    (Buffer('foo\nbar'), 4, None, 1),
+    (Buffer('foo\nbar'), 5, None, 1),
+    (Buffer('foo\nbar'), 6, None, 1),
+    (Buffer('foo\nbar\nbaz'), 7, None, 1),
+    (Buffer('foo\nbar\nbaz'), 8, None, 2),
+    (Buffer('foo\nbar\nbaz'), 9, None, 2),
+    (Buffer('foo\nbar\nbaz'), 10, None, 2),
+])
+# yapf: enable
+def test_get_row(buffer_: Buffer, index: int, expected_exception: Optional[BufferIndexException],
+                 expected_row: int) -> None:
+    """Test illud.buffer.Buffer.get_row."""
+    if expected_exception is not None:
+        with pytest.raises(type(expected_exception)):
+            buffer_.get_row(index)
+    else:
+        row: int = buffer_.get_row(index)
+
+        assert row == expected_row
+
+
+# yapf: disable
 @pytest.mark.parametrize('buffer_, index, expected_exception, expected_column', [
     (Buffer(), 0, BufferIndexException(0, 0), None),
     (Buffer(' '), 0, None, 0),

--- a/tests/test_illud.py
+++ b/tests/test_illud.py
@@ -102,9 +102,9 @@ def test_evaluate(initial_state: IlludState, input_: Command,
 
 # yapf: disable
 @pytest.mark.parametrize('illud_state, result, expected_output', [
-    (IlludState(terminal_size=IntegerSize2D(1, 1)), None, '\x1b[;H\x1b[7m \x1b[m'),
-    (IlludState(Buffer('foo'), terminal_size=IntegerSize2D(3, 1)), None, '\x1b[;H\x1b[7mf\x1b[moo'),
-    (IlludState(Buffer('foo'), cursor_position=1, terminal_size=IntegerSize2D(3, 1)), None, '\x1b[;Hf\x1b[7mo\x1b[mo'),
+    (IlludState(terminal_size=IntegerSize2D(1, 1)), None, '\x1b[;H \x1b[;H\x1b[7m \x1b[;2H\x1b[m'),
+    (IlludState(Buffer('foo'), terminal_size=IntegerSize2D(3, 1)), None, '\x1b[;Hfoo\x1b[;H\x1b[7mf\x1b[;2H\x1b[m'),
+    (IlludState(Buffer('foo'), cursor_position=1, terminal_size=IntegerSize2D(3, 1)), None, '\x1b[;Hfoo\x1b[;2H\x1b[7mo\x1b[;3H\x1b[m'),
 ])
 # yapf: enable
 def test_print(illud_state: IlludState, result: Any, expected_output: str) -> None:

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,7 +1,6 @@
 """Test illud.terminal."""
 import itertools
 import os
-from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -106,35 +105,35 @@ def test_move_cursor_home() -> None:
 
 
 # yapf: disable # pylint: disable=line-too-long
-@pytest.mark.parametrize('window, cursor, expected_output', [
-    (Window(IntegerPosition2D(), IntegerSize2D(0, 0), Buffer()), None, ''),
-    (Window(IntegerPosition2D(), IntegerSize2D(1, 1), Buffer()), None, '\x1b[;H '),
-    (Window(IntegerPosition2D(), IntegerSize2D(2, 1), Buffer()), None, '\x1b[;H  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer()), None, '\x1b[;H   '),
-    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer()), None, '\x1b[;H \x1b[2;H '),
-    (Window(IntegerPosition2D(), IntegerSize2D(2, 2), Buffer()), None, '\x1b[;H  \x1b[2;H  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(2, 1), Buffer('foo')), None, '\x1b[;Hfo'),
-    (Window(IntegerPosition2D(), IntegerSize2D(2, 2), Buffer('foo')), None, '\x1b[;Hfo\x1b[2;H  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('foo')), None, '\x1b[;Hfoo'),
-    (Window(IntegerPosition2D(), IntegerSize2D(5, 1), Buffer('foo')), None, '\x1b[;Hfoo  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(5, 1), Buffer('foo\n')), None, '\x1b[;Hfoo  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('f')), None, '\x1b[;Hf\x1b[2;H '),
-    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('f\nb')), None, '\x1b[;Hf\x1b[2;Hb'),
-    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('foo\nb')), None, '\x1b[;Hf\x1b[2;Hb'),
-    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('foo\nbar')), None, '\x1b[;Hf\x1b[2;Hb'),
-    (Window(IntegerPosition2D(), IntegerSize2D(2, 2), Buffer('f\nb')), None, '\x1b[;Hf \x1b[2;Hb '),
-    (Window(IntegerPosition2D(), IntegerSize2D(5, 2), Buffer('foo\nbar')), None, '\x1b[;Hfoo  \x1b[2;Hbar  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(5, 2), Buffer('foo\nbar')), None, '\x1b[;Hfoo  \x1b[2;Hbar  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(5, 3), Buffer('foo\nbar\nbaz')), None, '\x1b[;Hfoo  \x1b[2;Hbar  \x1b[3;Hbaz  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(0, 0), Buffer()), Cursor(Buffer(), 0), ''),
-    (Window(IntegerPosition2D(), IntegerSize2D(1, 1), Buffer('')), Cursor(Buffer(''), 0), '\x1b[;H\x1b[7m \x1b[m'),
-    (Window(IntegerPosition2D(), IntegerSize2D(4, 1), Buffer('foo')), Cursor(Buffer(''), 3), '\x1b[;Hfoo\x1b[7m \x1b[m'),
-    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('   ')), Cursor(Buffer('   '), 0), '\x1b[;H\x1b[7m \x1b[m  '),
-    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('   ')), Cursor(Buffer('   '), 1), '\x1b[;H \x1b[7m \x1b[m '),
-    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('foo')), Cursor(Buffer('foo'), 0), '\x1b[;H\x1b[7mf\x1b[moo'),
+@pytest.mark.parametrize('window, expected_output', [
+    (Window(IntegerPosition2D(), IntegerSize2D(0, 0), Buffer()), ''),
+    (Window(IntegerPosition2D(), IntegerSize2D(1, 1), Buffer()), '\x1b[;H '),
+    (Window(IntegerPosition2D(), IntegerSize2D(2, 1), Buffer()), '\x1b[;H  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer()), '\x1b[;H   '),
+    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer()), '\x1b[;H \x1b[2;H '),
+    (Window(IntegerPosition2D(), IntegerSize2D(2, 2), Buffer()), '\x1b[;H  \x1b[2;H  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(2, 1), Buffer('foo')), '\x1b[;Hfo'),
+    (Window(IntegerPosition2D(), IntegerSize2D(2, 2), Buffer('foo')), '\x1b[;Hfo\x1b[2;H  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('foo')), '\x1b[;Hfoo'),
+    (Window(IntegerPosition2D(), IntegerSize2D(5, 1), Buffer('foo')), '\x1b[;Hfoo  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(5, 1), Buffer('foo\n')), '\x1b[;Hfoo  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('f')), '\x1b[;Hf\x1b[2;H '),
+    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('f\nb')), '\x1b[;Hf\x1b[2;Hb'),
+    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('foo\nb')), '\x1b[;Hf\x1b[2;Hb'),
+    (Window(IntegerPosition2D(), IntegerSize2D(1, 2), Buffer('foo\nbar')), '\x1b[;Hf\x1b[2;Hb'),
+    (Window(IntegerPosition2D(), IntegerSize2D(2, 2), Buffer('f\nb')), '\x1b[;Hf \x1b[2;Hb '),
+    (Window(IntegerPosition2D(), IntegerSize2D(5, 2), Buffer('foo\nbar')), '\x1b[;Hfoo  \x1b[2;Hbar  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(5, 2), Buffer('foo\nbar')), '\x1b[;Hfoo  \x1b[2;Hbar  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(5, 3), Buffer('foo\nbar\nbaz')), '\x1b[;Hfoo  \x1b[2;Hbar  \x1b[3;Hbaz  '),
+    (Window(IntegerPosition2D(), IntegerSize2D(0, 0), Buffer()), ''),
+    (Window(IntegerPosition2D(), IntegerSize2D(1, 1), Buffer('')), '\x1b[;H '),
+    (Window(IntegerPosition2D(), IntegerSize2D(4, 1), Buffer('foo')), '\x1b[;Hfoo '),
+    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('   ')), '\x1b[;H   '),
+    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('   ')), '\x1b[;H   '),
+    (Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('foo')), '\x1b[;Hfoo'),
 ])
 # yapf: enable # pylint: enable=line-too-long
-def test_draw_window(window: Window, cursor: Optional[Cursor], expected_output: str) -> None:
+def test_draw_window(window: Window, expected_output: str) -> None:
     """Test illud.terminal.Terminal.draw_window."""
     standard_output_mock = MagicMock(StandardOutput)
     with patch('illud.terminal.StandardInput'), \
@@ -145,7 +144,7 @@ def test_draw_window(window: Window, cursor: Optional[Cursor], expected_output: 
 
         standard_output_mock.write.reset_mock()
 
-        terminal.draw_window(window, cursor)
+        terminal.draw_window(window)
 
     calls_args = itertools.chain.from_iterable(
         call_args for call_args, _ in standard_output_mock.write.call_args_list)
@@ -166,3 +165,38 @@ def test_update() -> None:
         terminal.update()
 
     standard_output_mock.flush.assert_called_once()
+
+
+# yapf: disable
+@pytest.mark.parametrize('cursor, expected_output', [
+    (Cursor(Buffer(), 0), '\x1b[;H\x1b[7m \x1b[;2H\x1b[m'),
+    (Cursor(Buffer('foo'), 0), '\x1b[;H\x1b[7mf\x1b[;2H\x1b[m'),
+    (Cursor(Buffer('foo'), 1), '\x1b[;2H\x1b[7mo\x1b[;3H\x1b[m'),
+    (Cursor(Buffer('foo'), 2), '\x1b[;3H\x1b[7mo\x1b[;4H\x1b[m'),
+    (Cursor(Buffer('foo'), 3), '\x1b[;4H\x1b[7m \x1b[;5H\x1b[m'),
+    (Cursor(Buffer('foo\n'), 3), '\x1b[;4H\x1b[7m \x1b[;5H\x1b[m'),
+    (Cursor(Buffer('foo\nbar'), 3), '\x1b[;4H\x1b[7m \x1b[;5H\x1b[m'),
+    (Cursor(Buffer('foo\nbar'), 4), '\x1b[2;H\x1b[7mb\x1b[2;2H\x1b[m'),
+    (Cursor(Buffer('foo\nbar'), 5), '\x1b[2;2H\x1b[7ma\x1b[2;3H\x1b[m'),
+    (Cursor(Buffer('foo\nbar'), 6), '\x1b[2;3H\x1b[7mr\x1b[2;4H\x1b[m'),
+    (Cursor(Buffer('foo\nbar'), 7), '\x1b[2;4H\x1b[7m \x1b[2;5H\x1b[m'),
+])
+# yapf: enable
+def test_draw_cursor(cursor: Cursor, expected_output: str) -> None:
+    """Test illud.terminal.Terminal.draw_cursor."""
+    standard_output_mock = MagicMock(StandardOutput)
+    with patch('illud.terminal.StandardInput'), \
+        patch('illud.terminal.StandardOutput', return_value=standard_output_mock), \
+        patch('illud.terminal_cursor.TerminalCursor._get_position_from_terminal'):
+
+        terminal: Terminal = Terminal()
+
+        standard_output_mock.write.reset_mock()
+
+        terminal.draw_cursor(cursor)
+
+    calls_args = itertools.chain.from_iterable(
+        call_args for call_args, _ in standard_output_mock.write.call_args_list)
+    output: str = ''.join(calls_args)
+
+    assert list(output) == list(expected_output)


### PR DESCRIPTION
Seperate cursor drawing from window drawing. This does mean that we end
up writing more characters to stdout right now, but it has some
advantages. We no longer violate the single responsibility principle and
it makes the code easier to understand. Eventually, we can introduce a
layer between the terminal representation and the actual terminal which
handles all the drawing for us and gives us a much better interface than
printing directly.