### PR TITLE
Change Illud state initialization

### DIFF
--- a/illud/illud_state.py
+++ b/illud/illud_state.py
@@ -18,10 +18,13 @@ from illud.window import Window
 
 class IlludState(State):
     """Persistent information of Illud."""
+
+    # pylint: disable=too-many-arguments
     def __init__(self,
                  buffer_: Optional[Buffer] = None,
-                 cursor_position: Optional[int] = None,
+                 cursor: Optional[Cursor] = None,
                  mode: Optional[Mode] = None,
+                 window: Optional[Window] = None,
                  terminal_size: Optional[IntegerSize2D] = None):
         self.buffer: Buffer
         if buffer_ is None:
@@ -30,10 +33,10 @@ class IlludState(State):
             self.buffer = buffer_
 
         self.cursor: Cursor
-        if cursor_position is None:
-            self.cursor = Cursor(self.buffer, 0)
+        if cursor is None:
+            self.cursor = Cursor(Buffer(), 0)
         else:
-            self.cursor = Cursor(self.buffer, cursor_position)
+            self.cursor = cursor
 
         self.mode: Mode
         if mode is None:
@@ -42,10 +45,16 @@ class IlludState(State):
             self.mode = mode
 
         self.window: Window
-        if terminal_size:
-            self.window = Window(IntegerPosition2D(), terminal_size, self.buffer)
+        if window is None:
+            self.window = Window(IntegerPosition2D(), IntegerSize2D(0, 0), Buffer())
         else:
-            self.window = Window(IntegerPosition2D(), IntegerSize2D(0, 0), self.buffer)
+            self.window = window
+
+        self.terminal_size: IntegerSize2D
+        if terminal_size is None:
+            self.terminal_size = IntegerSize2D(0, 0)
+        else:
+            self.terminal_size = terminal_size
 
     @staticmethod
     def from_file(file: str) -> 'IlludState':

--- a/tests/modes/test_insert.py
+++ b/tests/modes/test_insert.py
@@ -7,6 +7,7 @@ from illud.buffer import Buffer
 from illud.character import Character
 from illud.characters import BACKSPACE, CARRIAGE_RETURN, CONTROL_C, ESCAPE
 from illud.command import Command
+from illud.cursor import Cursor
 from illud.exceptions.quit_exception import QuitException
 from illud.illud_state import IlludState
 from illud.mode import Mode
@@ -23,11 +24,11 @@ def test_inheritance() -> None:
 @pytest.mark.parametrize('state, command, expected_state_after, expect_exits', [
     (IlludState(mode=Insert()), Command(Character(CONTROL_C)), None, True),
     (IlludState(mode=Insert()), Command(Character(ESCAPE)), IlludState(mode=Normal()), False),
-    (IlludState(mode=Insert()), Command(Character('a')), IlludState(buffer_=Buffer('a'), cursor_position=1, mode=Insert()), False),
-    (IlludState(buffer_=Buffer('foo'), mode=Insert()), Command(Character(BACKSPACE)), IlludState(buffer_=Buffer('foo'), mode=Insert()), False),
-    (IlludState(buffer_=Buffer('foo'), cursor_position=2, mode=Insert()), Command(Character('')), IlludState(buffer_=Buffer('fo'), cursor_position=1, mode=Insert()), False),
-    (IlludState(buffer_=Buffer(''), cursor_position=0, mode=Insert()), Command(Character(CARRIAGE_RETURN)), IlludState(buffer_=Buffer('\n'), cursor_position=1, mode=Insert()), False),
-    (IlludState(buffer_=Buffer('foo'), cursor_position=2, mode=Insert()), Command(Character(CARRIAGE_RETURN)), IlludState(buffer_=Buffer('fo\no'), cursor_position=3, mode=Insert()), False),
+    (IlludState(mode=Insert()), Command(Character('a')), IlludState(cursor=Cursor(Buffer('a'), 1), mode=Insert()), False),
+    (IlludState(cursor=Cursor(Buffer('foo'), 0), mode=Insert()), Command(Character(BACKSPACE)), IlludState(cursor=Cursor(Buffer('foo'), 0), mode=Insert()), False),
+    (IlludState(cursor=Cursor(Buffer('foo'), 2), mode=Insert()), Command(Character(BACKSPACE)), IlludState(cursor=Cursor(Buffer('fo'), 1), mode=Insert()), False),
+    (IlludState(cursor=Cursor(Buffer(''), 0), mode=Insert()), Command(Character(CARRIAGE_RETURN)), IlludState(cursor=Cursor(Buffer('\n'), 1), mode=Insert()), False),
+    (IlludState(cursor=Cursor(Buffer('foo'), 2), mode=Insert()), Command(Character(CARRIAGE_RETURN)), IlludState(cursor=Cursor(Buffer('fo\no'), 3), mode=Insert()), False),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_evaluate(state: IlludState, command: Command, expected_state_after: Optional[IlludState],

--- a/tests/modes/test_normal.py
+++ b/tests/modes/test_normal.py
@@ -7,6 +7,7 @@ from illud.buffer import Buffer
 from illud.character import Character
 from illud.characters import CONTROL_C
 from illud.command import Command
+from illud.cursor import Cursor
 from illud.exceptions.quit_exception import QuitException
 from illud.illud_state import IlludState
 from illud.mode import Mode
@@ -23,14 +24,14 @@ def test_inheritance() -> None:
 @pytest.mark.parametrize('state_before, command, expected_state_after, expect_exits', [
     (IlludState(), Command(Character('i')), IlludState(mode=Insert()), False),
     (IlludState(), Command(Character('d')), IlludState(), False),
-    (IlludState(Buffer('foo'), cursor_position=1), Command(Character('d')), IlludState(Buffer('foo')), False),
+    (IlludState(cursor=Cursor(Buffer('foo'), 1)), Command(Character('d')), IlludState(cursor=Cursor(Buffer('foo'), 0)), False),
     (IlludState(), Command(Character('f')), IlludState(), False),
-    (IlludState(Buffer('foo')), Command(Character('f')), IlludState(Buffer('foo'), cursor_position=1), False),
+    (IlludState(cursor=Cursor(Buffer('foo'), 0)), Command(Character('f')), IlludState(cursor=Cursor(Buffer('foo'), 1)), False),
     (IlludState(), Command(Character('j')), IlludState(), False),
     (IlludState(Buffer('foo')), Command(Character('k')), IlludState(Buffer('foo')), False),
-    (IlludState(Buffer('foo\nbar'), cursor_position=4), Command(Character('k')), IlludState(Buffer('foo\nbar')), False),
+    (IlludState(cursor=Cursor(Buffer('foo\nbar'), 4)), Command(Character('k')), IlludState(cursor=Cursor(Buffer('foo\nbar'), 0)), False),
     (IlludState(Buffer('foo')), Command(Character('j')), IlludState(Buffer('foo')), False),
-    (IlludState(Buffer('foo\nbar')), Command(Character('j')), IlludState(Buffer('foo\nbar'), cursor_position=4), False),
+    (IlludState(cursor=Cursor(Buffer('foo\nbar'), 0)), Command(Character('j')), IlludState(cursor=Cursor(Buffer('foo\nbar'), 4)), False),
     (IlludState(), Command(Character('k')), IlludState(), False),
     (IlludState(), Command(Character('f')), IlludState(), False),
     (IlludState(), Command(Character('d')), IlludState(), False),

--- a/tests/test_illud.py
+++ b/tests/test_illud.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+from seligimus.maths.integer_position_2d import IntegerPosition2D
 from seligimus.maths.integer_size_2d import IntegerSize2D
 
 from illud.ansi.escape_codes.cursor import MOVE_CURSOR_HOME
@@ -11,6 +12,7 @@ from illud.ansi.escape_codes.erase import CLEAR_SCREEN
 from illud.buffer import Buffer
 from illud.character import Character
 from illud.command import Command
+from illud.cursor import Cursor
 from illud.exceptions.quit_exception import QuitException
 from illud.illud import Illud
 from illud.illud_state import IlludState
@@ -18,6 +20,7 @@ from illud.modes.insert import Insert
 from illud.outputs.standard_output import StandardOutput
 from illud.repl import REPL
 from illud.terminal import Terminal
+from illud.window import Window
 
 
 def test_inheritance() -> None:
@@ -102,9 +105,9 @@ def test_evaluate(initial_state: IlludState, input_: Command,
 
 # yapf: disable
 @pytest.mark.parametrize('illud_state, result, expected_output', [
-    (IlludState(terminal_size=IntegerSize2D(1, 1)), None, '\x1b[;H \x1b[;H\x1b[7m \x1b[;2H\x1b[m'),
-    (IlludState(Buffer('foo'), terminal_size=IntegerSize2D(3, 1)), None, '\x1b[;Hfoo\x1b[;H\x1b[7mf\x1b[;2H\x1b[m'),
-    (IlludState(Buffer('foo'), cursor_position=1, terminal_size=IntegerSize2D(3, 1)), None, '\x1b[;Hfoo\x1b[;2H\x1b[7mo\x1b[;3H\x1b[m'),
+    (IlludState(window=Window(IntegerPosition2D(), IntegerSize2D(1, 1), Buffer())), None, '\x1b[;H \x1b[;H\x1b[7m \x1b[;2H\x1b[m'),
+    (IlludState(cursor=Cursor(Buffer('foo'), 0), window=Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('foo'))), None, '\x1b[;Hfoo\x1b[;H\x1b[7mf\x1b[;2H\x1b[m'),
+    (IlludState(cursor=Cursor(Buffer('foo'), 1), window=Window(IntegerPosition2D(), IntegerSize2D(3, 1), Buffer('foo'))), None, '\x1b[;Hfoo\x1b[;2H\x1b[7mo\x1b[;3H\x1b[m'),
 ])
 # yapf: enable
 def test_print(illud_state: IlludState, result: Any, expected_output: str) -> None:


### PR DESCRIPTION
Change Illud state to be initialized with sub-state directly.

There is a bit of a problem here: The state is a graph, but we are
treating it like a tree by using classes. For now, let's allow
passing each node in the graph so that the edge formation can be done
prior to initialization of Illud state. Eventually, it would be nice
to be able to construct the state from a dictionary (maybe even typed)
with the ability to use references to form edges.