### PR TITLE
Fix isorted files git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ venvs/*
 .mypy_cache
 
 # Ignore temporary files used by isort.
-.isorted
+*.isorted
 
 # Ignore test coverage.
 .coverage


### PR DESCRIPTION
Fix the git ignore pattern for isorted files. It needed a star so that
any file with the ending `.isorted` would be ignored.