### PR TITLE
Fix main file relativity

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -5,10 +5,7 @@ set -eu
 HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 ILLUD="${HERE}"
 
-cd "${ILLUD}"
-
 source "${ILLUD}/scripts/library/venv.sh"
 use_venv main frozen_requirements.txt
 
-
-python3 -m illud "$@"
+PYTHONPATH="${ILLUD}" python3 -m illud "$@"


### PR DESCRIPTION
Fix the main script to run Illud in the current working directory so
that the relativity of a file passed as an argument is correct.