### PR TITLE
Fix delete past end

### DIFF
--- a/illud/cursor.py
+++ b/illud/cursor.py
@@ -107,7 +107,7 @@ class Cursor():
 
     def delete(self) -> None:
         """Remove the character at the cursor position."""
-        if not self.buffer:
+        if not self.buffer or self.index == len(self.buffer):
             return
 
         self.buffer.delete(self.index)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -172,6 +172,7 @@ def test_backspace(cursor: Cursor, expected_cursor_after: Cursor) -> None:
 # yapf: disable
 @pytest.mark.parametrize('cursor, expected_cursor_after', [
     (Cursor(), Cursor()),
+    (Cursor(Buffer('a'), 1), Cursor(Buffer('a'), 1)),
     (Cursor(Buffer('foo')), Cursor(Buffer('oo'))),
     (Cursor(Buffer('foo'), 1), Cursor(Buffer('fo'), 1)),
     (Cursor(Buffer('foo'), 2), Cursor(Buffer('fo'), 1)),


### PR DESCRIPTION
Fix deleting a character if the cursor is past the end of the buffer.