### PR TITLE
Simplify cursor index default

### DIFF
--- a/illud/cursor.py
+++ b/illud/cursor.py
@@ -12,9 +12,9 @@ from illud.characters import WHITESPACE
 
 class Cursor():
     """A position in a string buffer."""
-    def __init__(self, buffer_: Optional[Buffer] = None, index: Optional[int] = None):
+    def __init__(self, buffer_: Optional[Buffer] = None, index: int = 0):
         self.buffer: Buffer = buffer_ if buffer_ is not None else Buffer()
-        self.index: int = index if index is not None else 0
+        self.index: int = index
 
     @standard_equality
     def __eq__(self, other: Any) -> bool:

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,5 +1,5 @@
 """Test illud.cursor."""
-from typing import Any, Optional
+from typing import Any, Dict, List
 
 import pytest
 from seligimus.maths.integer_position_2d import IntegerPosition2D
@@ -11,17 +11,20 @@ from illud.cursor import Cursor
 
 
 # yapf: disable
-@pytest.mark.parametrize('buffer_, index, expected_buffer, expected_index', [
-    (None, None, Buffer(), 0),
-    (Buffer(), None, Buffer(), 0),
-    (None, 0, Buffer(), 0),
-    (Buffer('foo'), 1, Buffer('foo'), 1),
+@pytest.mark.parametrize('arguments, keyword_arguments, expected_buffer, expected_index', [
+    ([], {}, Buffer(), 0),
+    ([Buffer('foo')], {}, Buffer('foo'), 0),
+    ([Buffer('foo'), 1], {}, Buffer('foo'), 1),
+    ([], {'buffer_': Buffer('foo')}, Buffer('foo'), 0),
+    ([], {'index': 1}, Buffer(), 1),
+    ([], {'buffer_': Buffer('foo'), 'index': 1}, Buffer('foo'), 1),
+    ([Buffer('foo')], {'index': 1}, Buffer('foo'), 1),
 ])
 # yapf: enable
-def test_init(buffer_: Optional[Buffer], index: Optional[int], expected_buffer: Buffer,
+def test_init(arguments: List[Any], keyword_arguments: Dict[str, Any], expected_buffer: Buffer,
               expected_index: int) -> None:
     """Test illud.cursor.Cursor.__init__."""
-    cursor: Cursor = Cursor(buffer_, index)
+    cursor: Cursor = Cursor(*arguments, **keyword_arguments)
 
     assert cursor.buffer == expected_buffer
     assert cursor.index == expected_index
@@ -44,8 +47,9 @@ def test_eq(cursor: Cursor, other: Any, expected_equality: bool) -> None:
 
 # yapf: disable
 @pytest.mark.parametrize('cursor, expected_representation', [
-    (Cursor(), 'Cursor(buffer_=Buffer(), index=0)'),
-    (Cursor(Buffer('foo')), "Cursor(buffer_=Buffer(string='foo'), index=0)"),
+    (Cursor(), 'Cursor(buffer_=Buffer())'),
+    (Cursor(Buffer('foo')), "Cursor(buffer_=Buffer(string='foo'))"),
+    (Cursor(index=1), "Cursor(buffer_=Buffer(), index=1)"),
 ])
 # yapf: enable
 def test_repr(cursor: Cursor, expected_representation: str) -> None:


### PR DESCRIPTION
Simplify the default cursor index by changing it from `None` to `0`
because `0` is immutable.