### PR TITLE
Add mode to status bar

### DIFF
--- a/illud/illud_state.py
+++ b/illud/illud_state.py
@@ -67,7 +67,10 @@ class IlludState(State):
         status_bar_position = IntegerPosition2D(0, max(terminal_size.y - 1, 0))
         status_bar_size = IntegerSize2D(
             terminal_size.x, 1) if terminal_size.y > 1 else IntegerSize2D(terminal_size.x, 0)
-        status_bar: StatusBar = StatusBar(position=status_bar_position, size=status_bar_size)
+        status_bar_buffer = Buffer(Normal.name)
+        status_bar: StatusBar = StatusBar(position=status_bar_position,
+                                          size=status_bar_size,
+                                          buffer_=status_bar_buffer)
 
         canvas: Canvas = Canvas(terminal_size).fill(' ')
         file: File = File(path)

--- a/illud/main.py
+++ b/illud/main.py
@@ -10,6 +10,7 @@ from illud.canvas import Canvas
 from illud.cursor import Cursor
 from illud.illud import Illud
 from illud.illud_state import IlludState
+from illud.modes.normal import Normal
 from illud.status_bar import StatusBar
 from illud.terminal import Terminal
 from illud.window import Window
@@ -49,7 +50,10 @@ def _run_illud(parsed_arguments: argparse.Namespace) -> None:
         status_bar_position = IntegerPosition2D(0, max(terminal_size.y - 1, 0))
         status_bar_size = IntegerSize2D(
             terminal_size.x, 1) if terminal_size.y > 1 else IntegerSize2D(terminal_size.x, 0)
-        status_bar: StatusBar = StatusBar(position=status_bar_position, size=status_bar_size)
+        status_bar_buffer = Buffer(Normal.name)
+        status_bar: StatusBar = StatusBar(position=status_bar_position,
+                                          size=status_bar_size,
+                                          buffer_=status_bar_buffer)
 
         canvas: Canvas = Canvas(terminal_size).fill(' ')
 

--- a/illud/mode.py
+++ b/illud/mode.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 from seligimus.python.decorators.operators.equality.equal_type import equal_type
 from seligimus.python.decorators.standard_representation import standard_representation
 
+from illud.buffer import Buffer
 from illud.character import Character
 from illud.characters import CONTROL_C, CONTROL_D, CONTROL_F, CONTROL_J, CONTROL_K, CONTROL_W
 from illud.exceptions.quit_exception import QuitException
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
 
 class Mode():
     """A manner of operation."""
+    name: str = ''
+
     @equal_type
     def __eq__(self, other: Any) -> bool:
         return True
@@ -22,8 +25,8 @@ class Mode():
     def __repr__(self) -> str:
         pass  # pragma: no cover
 
-    @staticmethod
-    def evaluate(state: 'IlludState', character: Character) -> None:
+    @classmethod
+    def evaluate(cls, state: 'IlludState', character: Character) -> None:
         """Evaluate the character for the given state."""
         if character.value == CONTROL_C:
             raise QuitException
@@ -39,3 +42,9 @@ class Mode():
         elif character.value == CONTROL_W:
             if state.file is not None:
                 state.file.write(state.buffer)
+
+    @staticmethod
+    def _change_mode(state: 'IlludState', mode: 'Mode') -> None:
+        """Change the current mode."""
+        state.status_bar.buffer = Buffer(mode.name)
+        state.mode = mode

--- a/illud/modes/insert.py
+++ b/illud/modes/insert.py
@@ -11,15 +11,17 @@ if TYPE_CHECKING:
 
 class Insert(Mode):  # pylint: disable=too-few-public-methods
     """Mode for inserting text."""
-    @staticmethod
-    def evaluate(state: 'IlludState', character: Character) -> None:
+    name: str = 'Insert'
+
+    @classmethod
+    def evaluate(cls, state: 'IlludState', character: Character) -> None:
         """Evaluate the character for the given state."""
         super(Insert, Insert).evaluate(state, character)
 
         if character.value == ESCAPE:
             from illud.modes.normal import \
                 Normal  # pylint: disable=import-outside-toplevel, cyclic-import
-            state.mode = Normal()
+            cls._change_mode(state, Normal())
         elif character.value == CARRIAGE_RETURN:
             state.cursor.insert(NEWLINE)
             state.window.adjust_view_to_include(state.cursor.index)

--- a/illud/modes/normal.py
+++ b/illud/modes/normal.py
@@ -14,8 +14,10 @@ if TYPE_CHECKING:
 
 class Normal(Mode):  # pylint: disable=too-few-public-methods
     """Mode for navigating and manipulating text."""
-    @staticmethod
-    def evaluate(state: 'IlludState', character: Character) -> None:  # pylint: disable=too-many-branches
+    name: str = 'Normal'
+
+    @classmethod
+    def evaluate(cls, state: 'IlludState', character: Character) -> None:  # pylint: disable=too-many-branches
         super(Normal, Normal).evaluate(state, character)
 
         if character.value == 'd':
@@ -51,9 +53,9 @@ class Normal(Mode):  # pylint: disable=too-few-public-methods
                 state.clipboard = Buffer(cursor_character)
             state.cursor.delete()
         elif character.value == 'i':
-            state.mode = Insert()
+            cls._change_mode(state, Insert())
         elif character.value == 's':
-            state.mode = Select()
+            cls._change_mode(state, Select())
             state.selection = Selection.from_cursor(state.cursor)
         elif character.value == 'p':
             if state.clipboard:

--- a/illud/modes/select.py
+++ b/illud/modes/select.py
@@ -11,15 +11,17 @@ if TYPE_CHECKING:
 
 class Select(Mode):  # pylint: disable=too-few-public-methods
     """Mode for selecting text."""
-    @staticmethod
-    def evaluate(state: 'IlludState', character: Character) -> None:
+    name: str = 'Select'
+
+    @classmethod
+    def evaluate(cls, state: 'IlludState', character: Character) -> None:
         """Evaluate the character for the given state."""
         super(Select, Select).evaluate(state, character)
 
         if character.value == ESCAPE:
             from illud.modes.normal import \
                 Normal  # pylint: disable=import-outside-toplevel, cyclic-import
-            state.mode = Normal()
+            cls._change_mode(state, Normal())
         elif character.value == 'f':
             if state.selection is not None:
                 state.selection.expand_right()
@@ -29,4 +31,4 @@ class Select(Mode):  # pylint: disable=too-few-public-methods
                 state.selection = None
             from illud.modes.normal import \
                 Normal  # pylint: disable=import-outside-toplevel, cyclic-import
-            state.mode = Normal()
+            cls._change_mode(state, Normal())

--- a/tests/modes/test_insert.py
+++ b/tests/modes/test_insert.py
@@ -14,7 +14,13 @@ from illud.illud_state import IlludState
 from illud.mode import Mode
 from illud.modes.insert import Insert
 from illud.modes.normal import Normal
+from illud.status_bar import StatusBar
 from illud.window import Window
+
+
+def test_name() -> None:
+    """Test illud.modes.insert.Insert.name."""
+    assert Insert.name == 'Insert'
 
 
 def test_inheritance() -> None:
@@ -29,7 +35,7 @@ _buffer_1 = Buffer()
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('state, character, expected_state_after, expect_exits', [
     (IlludState(mode=Insert()), Character(CONTROL_C), None, True),
-    (IlludState(mode=Insert()), Character(ESCAPE), IlludState(mode=Normal()), False),
+    (IlludState(mode=Insert()), Character(ESCAPE), IlludState(mode=Normal(), status_bar=StatusBar(buffer_=Buffer('Normal'))), False),
     (IlludState(mode=Insert()), Character('a'), IlludState(cursor=Cursor(Buffer('a'), 1), mode=Insert()), False),
     (IlludState(cursor=Cursor(_buffer_0, 2), mode=Insert(), window=Window(size=IntegerSize2D(2, 1), buffer_=_buffer_0, offset=IntegerPosition2D(-1, 0))), Character('o'), IlludState(cursor=Cursor(Buffer('foo'), 3), mode=Insert(), window=Window(size=IntegerSize2D(2, 1), buffer_=Buffer('foo'), offset=IntegerPosition2D(-2, 0))), False),
     (IlludState(cursor=Cursor(Buffer('foo')), mode=Insert()), Character(BACKSPACE), IlludState(cursor=Cursor(Buffer('foo')), mode=Insert()), False),

--- a/tests/modes/test_normal.py
+++ b/tests/modes/test_normal.py
@@ -16,7 +16,13 @@ from illud.modes.insert import Insert
 from illud.modes.normal import Normal
 from illud.modes.select import Select
 from illud.selection import Selection
+from illud.status_bar import StatusBar
 from illud.window import Window
+
+
+def test_name() -> None:
+    """Test illud.modes.normal.Normal.name."""
+    assert Normal.name == 'Normal'
 
 
 def test_inheritance() -> None:
@@ -26,9 +32,9 @@ def test_inheritance() -> None:
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('state_before, character, expected_state_after, expect_exits', [
-    (IlludState(), Character('i'), IlludState(mode=Insert()), False),
-    (IlludState(), Character('s'), IlludState(mode=Select(), selection=Selection()), False),
-    (IlludState(cursor=Cursor(Buffer('foo'), 1)), Character('s'), IlludState(mode=Select(), cursor=Cursor(Buffer('foo'), 1), selection=Selection(Buffer('foo'), 1, 1)), False),
+    (IlludState(), Character('i'), IlludState(mode=Insert(), status_bar=StatusBar(buffer_=Buffer('Insert'))), False),
+    (IlludState(), Character('s'), IlludState(mode=Select(), status_bar=StatusBar(buffer_=Buffer('Select')), selection=Selection()), False),
+    (IlludState(cursor=Cursor(Buffer('foo'), 1)), Character('s'), IlludState(mode=Select(), cursor=Cursor(Buffer('foo'), 1), status_bar=StatusBar(buffer_=Buffer('Select')), selection=Selection(Buffer('foo'), 1, 1)), False),
     (IlludState(), Character('d'), IlludState(), False),
     (IlludState(cursor=Cursor(Buffer('foo'), 1)), Character('d'), IlludState(cursor=Cursor(Buffer('foo'))), False),
     (IlludState(), Character('f'), IlludState(), False),

--- a/tests/modes/test_select.py
+++ b/tests/modes/test_select.py
@@ -12,6 +12,12 @@ from illud.mode import Mode
 from illud.modes.normal import Normal
 from illud.modes.select import Select
 from illud.selection import Selection
+from illud.status_bar import StatusBar
+
+
+def test_name() -> None:
+    """Test illud.modes.select.Select.name."""
+    assert Select.name == 'Select'
 
 
 def test_inheritance() -> None:
@@ -22,9 +28,9 @@ def test_inheritance() -> None:
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('state, character, expected_state_after, expect_exits', [
     (IlludState(mode=Select()), Character(CONTROL_C), None, True),
-    (IlludState(mode=Select()), Character(ESCAPE), IlludState(mode=Normal()), False),
+    (IlludState(mode=Select()), Character(ESCAPE), IlludState(mode=Normal(), status_bar=StatusBar(buffer_=Buffer('Normal'))), False),
     (IlludState(mode=Select(), selection=Selection(Buffer('foo'))), Character('f'), IlludState(mode=Select(), selection=Selection(Buffer('foo'), end=1)), False),
-    (IlludState(mode=Select(), selection=Selection(Buffer('foo'), 1, 2)), Character('y'), IlludState(mode=Normal(), clipboard=Buffer('oo')), False),
+    (IlludState(mode=Select(), selection=Selection(Buffer('foo'), 1, 2)), Character('y'), IlludState(mode=Normal(), status_bar=StatusBar(buffer_=Buffer('Normal')), clipboard=Buffer('oo')), False),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_evaluate(state: IlludState, character: Character,

--- a/tests/test_illud.py
+++ b/tests/test_illud.py
@@ -108,7 +108,7 @@ def test_read(signals: Signals, character: Character, expected_input: IlludInput
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('initial_state, input_, terminal_size, expected_state_after', [
-    (IlludState(), Character('i'), None, IlludState(mode=Insert())),
+    (IlludState(), Character('i'), None, IlludState(mode=Insert(), status_bar=StatusBar(buffer_=Buffer('Insert')))),
     (IlludState(), TerminalSizeChange(), IntegerSize2D(120, 80), IlludState(window=Window(size=IntegerSize2D(120, 80)), canvas=Canvas(IntegerSize2D(120, 80)).fill(' '), terminal_size=IntegerSize2D(120, 80))),
 ])
 # yapf: enable # pylint: enable=line-too-long

--- a/tests/test_illud_state.py
+++ b/tests/test_illud_state.py
@@ -65,9 +65,9 @@ def test_init(arguments: List[Any], keyword_arguments: Dict[str, Any],
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('path, file_contents, file_exists, terminal_size, expected_illud_state', [
-    ('foo.txt', None, False, IntegerSize2D(0, 0), IlludState(file=File('foo.txt'))),
-    ('foo.txt', '', True, IntegerSize2D(0, 0), IlludState(file=File('foo.txt'))),
-    ('foo.txt', 'Lorem ipsum dolor sit amet', True, IntegerSize2D(120, 80), IlludState(terminal_size=IntegerSize2D(120, 80), buffer_=Buffer('Lorem ipsum dolor sit amet'), cursor=Cursor(Buffer('Lorem ipsum dolor sit amet')), window=Window(size=IntegerSize2D(120, 79), buffer_=Buffer('Lorem ipsum dolor sit amet')), status_bar=StatusBar(position=IntegerPosition2D(0, 79), size=IntegerSize2D(120, 1)), canvas=Canvas(IntegerSize2D(120, 80)).fill(' '), file=File('foo.txt'))),
+    ('foo.txt', None, False, IntegerSize2D(0, 0), IlludState(file=File('foo.txt'), status_bar=StatusBar(buffer_=Buffer('Normal')))),
+    ('foo.txt', '', True, IntegerSize2D(0, 0), IlludState(file=File('foo.txt'), status_bar=StatusBar(buffer_=Buffer('Normal')))),
+    ('foo.txt', 'Lorem ipsum dolor sit amet', True, IntegerSize2D(120, 80), IlludState(terminal_size=IntegerSize2D(120, 80), buffer_=Buffer('Lorem ipsum dolor sit amet'), cursor=Cursor(Buffer('Lorem ipsum dolor sit amet')), window=Window(size=IntegerSize2D(120, 79), buffer_=Buffer('Lorem ipsum dolor sit amet')), status_bar=StatusBar(position=IntegerPosition2D(0, 79), size=IntegerSize2D(120, 1), buffer_=Buffer('Normal')), canvas=Canvas(IntegerSize2D(120, 80)).fill(' '), file=File('foo.txt'))),
 ])
 # yapf: enable # pylint: enable=line-too-long
 def test_from_file(path: str, file_contents: Optional[str], file_exists: bool,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,7 +79,7 @@ def test_parse_arguments(argument_parser: argparse.ArgumentParser, arguments: Li
 
 # yapf: disable # pylint: disable=line-too-long
 @pytest.mark.parametrize('parsed_arguments, illud_state_from_file, terminal_size, expected_init_arguments', [
-    (argparse.Namespace(file=None), None, IntegerSize2D(120, 80), [IlludState(terminal_size=IntegerSize2D(120, 80), buffer_=Buffer(), cursor=Cursor(), window=Window(size=IntegerSize2D(120, 79)), status_bar=StatusBar(position=IntegerPosition2D(0, 79), size=IntegerSize2D(120, 1)), canvas=Canvas(IntegerSize2D(120, 80)).fill(' '))]),
+    (argparse.Namespace(file=None), None, IntegerSize2D(120, 80), [IlludState(terminal_size=IntegerSize2D(120, 80), buffer_=Buffer(), cursor=Cursor(), window=Window(size=IntegerSize2D(120, 79)), status_bar=StatusBar(position=IntegerPosition2D(0, 79), size=IntegerSize2D(120, 1), buffer_=Buffer('Normal')), canvas=Canvas(IntegerSize2D(120, 80)).fill(' '))]),
     (argparse.Namespace(file='foo.py'), IlludState(terminal_size=IntegerSize2D(120, 80), buffer_=Buffer('Lorem ipsum'), canvas=Canvas(IntegerSize2D(120, 80)).fill(' '), file=File('foo.py')), IntegerSize2D(120, 80), [IlludState(terminal_size=IntegerSize2D(120, 80), buffer_=Buffer('Lorem ipsum'), canvas=Canvas(IntegerSize2D(120, 80)).fill(' '), file=File('foo.py'))]),
 ])
 # yapf: enable # pylint: enable=line-too-long

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -6,13 +6,20 @@ import pytest
 from seligimus.maths.integer_position_2d import IntegerPosition2D
 from seligimus.maths.integer_size_2d import IntegerSize2D
 
+from illud.buffer import Buffer
 from illud.character import Character
 from illud.characters import CONTROL_C, CONTROL_D, CONTROL_F, CONTROL_J, CONTROL_K, CONTROL_W
 from illud.exceptions.quit_exception import QuitException
 from illud.file import File
 from illud.illud_state import IlludState
 from illud.mode import Mode
+from illud.status_bar import StatusBar
 from illud.window import Window
+
+
+def test_name() -> None:
+    """Test illud.mode.Mode.name."""
+    assert Mode.name == ''
 
 
 # yapf: disable
@@ -73,3 +80,20 @@ def test_evaluate(state_before: IlludState, character: Character,
             file_write_mock.assert_not_called()
 
     assert state_before == expected_state_after
+
+
+class Foo(Mode):  # pylint: disable=too-few-public-methods
+    """A mock mode."""
+    name: str = 'Foo'
+
+
+# yapf: disable
+@pytest.mark.parametrize('state, mode, expected_state_after', [
+    (IlludState(), Foo(), IlludState(mode=Foo(), status_bar=StatusBar(buffer_=Buffer('Foo')))),
+])
+# yapf: enable
+def test_change_mode(state: IlludState, mode: Mode, expected_state_after: IlludState) -> None:
+    """Test illud.mode.Mode._change_mode"""
+    Mode._change_mode(state, mode)  # pylint: disable=protected-access
+
+    assert state == expected_state_after


### PR DESCRIPTION
Add the name of the current mode to the status bar. Long term we need
to come up with a better way of managing state display. For example,
there could be a mechanism for registing callbacks when certain pieces
of state change. So something would be called when the mode changes and
that would change the status bar. Status bar layout also probably needs
some work. It might make sense to have several windows for it which are
grouped.