### PR TITLE
Add backspace in normal mode

### DIFF
--- a/illud/modes/normal.py
+++ b/illud/modes/normal.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional
 
 from illud.buffer import Buffer
 from illud.character import Character
+from illud.characters import BACKSPACE
 from illud.mode import Mode
 from illud.modes.insert import Insert
 from illud.modes.replace import Replace
@@ -63,3 +64,5 @@ class Normal(Mode):  # pylint: disable=too-few-public-methods
         elif character.value == 'p':
             if state.clipboard:
                 state.cursor.insert(state.clipboard.string)
+        elif character.value == BACKSPACE:
+            state.cursor.backspace()

--- a/tests/modes/test_normal.py
+++ b/tests/modes/test_normal.py
@@ -7,7 +7,7 @@ from seligimus.maths.integer_size_2d import IntegerSize2D
 
 from illud.buffer import Buffer
 from illud.character import Character
-from illud.characters import CONTROL_C
+from illud.characters import BACKSPACE, CONTROL_C
 from illud.cursor import Cursor
 from illud.exceptions.quit_exception import QuitException
 from illud.illud_state import IlludState
@@ -59,6 +59,7 @@ def test_inheritance() -> None:
     (IlludState(cursor=Cursor(Buffer('foo bar')), window=Window(size=IntegerSize2D(2, 1), buffer_=Buffer('foo bar'))), Character('w'), IlludState(cursor=Cursor(Buffer('foo bar'), 4), window=Window(size=IntegerSize2D(2, 1), buffer_=Buffer('foo bar'), offset=IntegerPosition2D(-3, 0))), False),
     (IlludState(cursor=Cursor(Buffer('foo'))), Character('x'), IlludState(cursor=Cursor(Buffer('oo')), clipboard=Buffer('f')), False),
     (IlludState(cursor=Cursor(Buffer('foobaz'), 3), clipboard=Buffer('bar')), Character('p'), IlludState(cursor=Cursor(Buffer('foobarbaz'), 6), clipboard=Buffer('bar')), False),
+    (IlludState(cursor=Cursor(Buffer('bar'), 3)), Character(BACKSPACE), IlludState(cursor=Cursor(Buffer('ba'), 2)), False),
     (IlludState(), Character(CONTROL_C), None, True),
 ])
 # yapf: enable # pylint: enable=line-too-long


### PR DESCRIPTION
Add the ability to use backspace in normal mode to remove the previous
character and adjust the cursor appropriately.